### PR TITLE
US-28 Crear un servicio que utilice HttpClient 

### DIFF
--- a/frontend/src/app/services/dataservice.service.spec.ts
+++ b/frontend/src/app/services/dataservice.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DataserviceService } from './dataservice.service';
+
+describe('DataserviceService', () => {
+  let service: DataserviceService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DataserviceService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/src/app/services/dataservice.service.ts
+++ b/frontend/src/app/services/dataservice.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DataserviceService {
+  private apiUrl = 'http://localhost:3000';
+
+  constructor(private http: HttpClient) { }
+
+  getAll(entity: string) {
+    return this.http.get<any>(`${this.apiUrl}/${entity}`)
+  }
+
+  getById(entity: string, id: number) {
+    return this.http.get<any>(`${this.apiUrl}/${entity}/${id}`);
+  }
+
+
+
+
+}

--- a/frontend/src/app/services/dataservice.service.ts
+++ b/frontend/src/app/services/dataservice.service.ts
@@ -17,7 +17,16 @@ export class DataserviceService {
     return this.http.get<any>(`${this.apiUrl}/${entity}/${id}`);
   }
 
+  insert(entity: string, data: any) {
+    return this.http.post<any>(`${this.apiUrl}/${entity}`, data);
+  }
 
+  update(entity: string, id: number, data: any) {
+    return this.http.put<any>(`${this.apiUrl}/${entity}/${id}`, data);
+  }
 
+  delete(entity: string, id: number) {
+    return this.http.delete<any>(`${this.apiUrl}/${entity}/${id}`);
+  }
 
 }


### PR DESCRIPTION
Completos los siguientes paso:

 - Se ha creado un servicio en Angular que utiliza HttpClient para realizar peticiones HTTP a una API REST de prueba (utilizando json-server).
-  El servicio tiene métodos que permiten obtener, crear, actualizar y eliminar datos de la base de datos.
-  Los métodos del servicio son multipropósito, es decir, pueden ser utilizados por todos los componentes de la aplicación para acceder a los datos de la base de datos.
-  Los métodos del servicio retornan los datos de la API REST en formato JSON.